### PR TITLE
Fix: group and resource comments warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 3.1.0
 
 - handle Group and Resource comments
-- add optional `ignoreComments` parameter to `ftl2js`
+- add optional `respectComments` parameter to `ftl2js`
 
 ### 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 3.1.0
+
+- handle Group and Resource comments
+
 ### 3.0.1
 
 - transpile also esm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 3.1.0
 
 - handle Group and Resource comments
+- add optional `ignoreComments` parameter to `ftl2js`
 
 ### 3.0.1
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import fluent from 'fluent_conv'
 // or
 const fluent = require('fluent_conv')
 
-fluent.ftl2js(str, (err, res) => {}, { ignoreComments: false })
+fluent.ftl2js(str, (err, res) => {}, { respectComments: true })
 ```
 
 Or you can direclty `import` or `require()` its functions:
@@ -32,9 +32,9 @@ const ftl2js = require('fluent_conv/cjs/ftl2js')
 
 ```js
 {
-    // Ignore all kind of comments.
+    // If set to `false` will ignore all kind of comments.
     // Useful for one-way conversion from ftl to js files.
-    ignoreComments: false,
+    respectComments: true,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import fluent from 'fluent_conv'
 // or
 const fluent = require('fluent_conv')
 
-fluent.ftl2js(str, (err, res) => {})
+fluent.ftl2js(str, (err, res) => {}, { ignoreComments: false })
 ```
 
 Or you can direclty `import` or `require()` its functions:
@@ -26,6 +26,16 @@ Or you can direclty `import` or `require()` its functions:
 import ftl2js from 'fluent_conv/ftl2js'
 // or
 const ftl2js = require('fluent_conv/cjs/ftl2js')
+```
+
+## `ftl2js` optional parameters
+
+```js
+{
+    // Ignore all kind of comments.
+    // Useful for one-way conversion from ftl to js files.
+    ignoreComments: false,
+}
 ```
 
 ## Usage

--- a/lib/ftl2js.js
+++ b/lib/ftl2js.js
@@ -1,7 +1,7 @@
 import { parse } from '@fluent/syntax'
 import serializer from './ftl2jsSerializer.js'
 
-export default function ftlToJs (str, cb, params = { ignoreComments: false }) {
+export default function ftlToJs (str, cb, params = { respectComments: true }) {
   if (typeof str !== 'string') {
     if (!cb) throw new Error('The first parameter was not a string')
     return cb(new Error('The first parameter was not a string'))
@@ -14,7 +14,7 @@ export default function ftlToJs (str, cb, params = { ignoreComments: false }) {
     if (!item) return mem
     if (
       (item.attributes && item.attributes.length) ||
-      (item.comment && !params.ignoreComments)
+      (item.comment && params.respectComments)
     ) {
       const inner = {}
       if (item.comment) inner[item.comment.key] = item.comment.value

--- a/lib/ftl2js.js
+++ b/lib/ftl2js.js
@@ -1,7 +1,7 @@
 import { parse } from '@fluent/syntax'
 import serializer from './ftl2jsSerializer.js'
 
-export default function ftlToJs (str, cb) {
+export default function ftlToJs (str, cb, params = { ignoreComments: false }) {
   if (typeof str !== 'string') {
     if (!cb) throw new Error('The first parameter was not a string')
     return cb(new Error('The first parameter was not a string'))
@@ -12,7 +12,10 @@ export default function ftlToJs (str, cb) {
   const result = parsed.body.reduce((mem, segment) => {
     const item = serializer.serialize(segment)
     if (!item) return mem
-    if ((item.attributes && item.attributes.length) || item.comment) {
+    if (
+      (item.attributes && item.attributes.length) ||
+      (item.comment && !params.ignoreComments)
+    ) {
       const inner = {}
       if (item.comment) inner[item.comment.key] = item.comment.value
       if (item.attributes && item.attributes.length) {

--- a/lib/ftl2jsSerializer.js
+++ b/lib/ftl2jsSerializer.js
@@ -13,6 +13,14 @@ export default {
     return { key: 'comment', value: item.content }
   },
 
+  getGroupComment () {
+    return null
+  },
+
+  getResourceComment () {
+    return null
+  },
+
   getMessage (item) {
     return {
       key: this[getTypeName(item.id)](item.id),


### PR DESCRIPTION
Fluent spec has 3 kind of comments with one, two or three hashes.
`#` - statement or standalone comments
`##` - group comments (always standalone)
`###` - resource comments (always standalone)

Since JSON can't guarantee the  order of the keys, we can ignore GroupComment and ResourceComment. Otherwise we can't place them into their initial spots during `js2ftl` running.

---

I also added an optional parameter to `ftl2js` to ignore comments and extract flat structure without nested value. I found it useful for one-way conversion from *.ftl to *.json files during build time. This way we can save some extra bytes in the resulting json and it looks more clean:

Before:
```js
{
    key: {
        comment: '',
        val: '',
    }
}
```

After with `ignoreComments: true`:
```js
{
    key: '',
}
```

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] documentation is changed or added