### PR TITLE
Support function calls as selectors

### DIFF
--- a/lib/ftl2jsSerializer.js
+++ b/lib/ftl2jsSerializer.js
@@ -122,7 +122,9 @@ export default {
     const variants = item.variants.map((variant) => {
       return this[getTypeName(variant)](variant)
     })
-
+    if (item.selector.type === 'FunctionReference') {
+      return '{ ' + id + ' ->\n' + variants.join('\n') + '\n}'
+    }
     return '{ $' + id + ' ->\n' + variants.join('\n') + '\n}'
   },
 
@@ -167,7 +169,7 @@ export default {
     return '  ' + ret
   },
 
-  getFunctionReference (item) {
+  getFunctionReference (item, plain) {
     let args = ''
 
     item.arguments.positional.forEach((p, i) => {
@@ -180,6 +182,7 @@ export default {
       args += `${n.name.name}: "${n.value.value}"`
     })
 
+    if (plain) return `${item.id.name}(${args})`
     return `{ ${item.id.name}(${args}) }`
   },
 

--- a/test/fixtures/example.ftl
+++ b/test/fixtures/example.ftl
@@ -34,3 +34,10 @@ today-is = Today is { DATETIME($date) }
 
 last-notice = Last checked: { DATETIME($lastChecked, day: "numeric", month: "long") }.
 
+function-with-selector =
+  There are
+  { NUMBER($count) ->
+    [4] four lights
+   *[other] { $count } lights
+  }
+

--- a/test/fixtures/example.json
+++ b/test/fixtures/example.json
@@ -15,5 +15,6 @@
   },
   "logout": "Logout",
   "today-is": "Today is { DATETIME($date) }",
-  "last-notice": "Last checked: { DATETIME($lastChecked, day: \"numeric\", month: \"long\") }."
+  "last-notice": "Last checked: { DATETIME($lastChecked, day: \"numeric\", month: \"long\") }.",
+  "function-with-selector": "There are\n{ NUMBER($count) ->\n  [4] four lights\n *[other] { $count } lights\n}"
 }


### PR DESCRIPTION
Using the return value of a function call as a selector was getting serialized with an extraneous dollar sign.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [ ] documentation is changed or added